### PR TITLE
fix: use Effect.matchEffect instead of Effect.match

### DIFF
--- a/src/part2-cli/breakpoints/3-typed-errors/index.ts
+++ b/src/part2-cli/breakpoints/3-typed-errors/index.ts
@@ -132,7 +132,7 @@ function main(url: string, options?: CLIOptions) {
 
     const finalString = buffer.join("\n");
     yield* _(
-      Effect.match(Option.fromNullable(options?.output), {
+      Effect.matchEffect(Option.fromNullable(options?.output), {
         onSuccess: (output) =>
           Effect.tryPromise(() => fs.writeFile(output, finalString)),
         onFailure: () => Console.log(finalString),


### PR DESCRIPTION
No command output  if using `Effect.match`